### PR TITLE
Updated azure devops authentication to correctly include an empty username in the auth header

### DIFF
--- a/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/PullRequestScannerBuilderExtensions.cs
+++ b/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/PullRequestScannerBuilderExtensions.cs
@@ -36,9 +36,7 @@ public static class PullRequestScannerBuilderExtensions
 
                 var azureDevOpsOptions = provider.GetRequiredService<AzureDevOpsOptions>();
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
-                    Convert.ToBase64String(
-                        Encoding.ASCII.GetBytes(
-                            $":{azureDevOpsOptions.PersonalAccessToken}")));
+                    Convert.ToBase64String(Encoding.ASCII.GetBytes(FormatAccessToken(azureDevOpsOptions?.PersonalAccessToken))));
 
                 client.BaseAddress =
                     new Uri(
@@ -51,5 +49,20 @@ public static class PullRequestScannerBuilderExtensions
             .AddSingleton<ITeamMembersProvider, AzureDevOpsTeamMembersProvider>();
 
         return pullRequestScannerBuilder.AddPullRequestProvider(ActivatorUtilities.GetServiceOrCreateInstance<AzureDevOpsPullRequestProvider>);
+    }
+
+    private static string FormatAccessToken(string personalAccessToken)
+    {
+        if (personalAccessToken == null)
+        {
+            throw new ArgumentNullException(nameof(personalAccessToken));
+        }
+
+        if (!personalAccessToken.Contains(':'))
+        {
+            return $":{personalAccessToken}";
+        }
+
+        return personalAccessToken;
     }
 }

--- a/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/PullRequestScannerBuilderExtensions.cs
+++ b/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/PullRequestScannerBuilderExtensions.cs
@@ -31,9 +31,15 @@ public static class PullRequestScannerBuilderExtensions
         pullRequestScannerBuilder.Services
             .AddHttpClient<AzureDevOpsHttpClient>((provider, client) =>
             {
+                client.DefaultRequestHeaders.Accept.Add(
+                    new MediaTypeWithQualityHeaderValue("application/json"));
+
                 var azureDevOpsOptions = provider.GetRequiredService<AzureDevOpsOptions>();
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
-                    Convert.ToBase64String(Encoding.ASCII.GetBytes(azureDevOpsOptions.PersonalAccessToken)));
+                    Convert.ToBase64String(
+                        Encoding.ASCII.GetBytes(
+                            $":{azureDevOpsOptions.PersonalAccessToken}")));
+
                 client.BaseAddress =
                     new Uri(
                         $"https://dev.azure.com/{azureDevOpsOptions.OrganizationSlug}/{azureDevOpsOptions.ProjectSlug}/_apis/git/");
@@ -43,7 +49,7 @@ public static class PullRequestScannerBuilderExtensions
             .AddTransient<IAzureDevOpsPullRequestService, AzureDevOpsPullRequestService>()
             .AddTransient<IAzureDevOpsMapper, AzureDevOpsMapper>()
             .AddSingleton<ITeamMembersProvider, AzureDevOpsTeamMembersProvider>();
-        
-        return pullRequestScannerBuilder.AddPullRequestProvider(ActivatorUtilities.GetServiceOrCreateInstance<AzureDevOpsPullRequestProvider>); 
+
+        return pullRequestScannerBuilder.AddPullRequestProvider(ActivatorUtilities.GetServiceOrCreateInstance<AzureDevOpsPullRequestProvider>);
     }
 }


### PR DESCRIPTION
Had an issues getting the scanner to authenticate with Azure DevOps.
When you use a PAT token with basic authentication it is expecting you to still sender the user name even though the username is empty. A colon just needs adding before the PAT so that it becomes **:**[PAT]
 
I took the example code from Microsoft and integrated it and the auth issue I was having went away. https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows