### PR TITLE
Added support for multiple Azure DevOps projects

### DIFF
--- a/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/AsyncEnumerableExtensions.cs
+++ b/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/AsyncEnumerableExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Immutable;
+
+namespace TomLonghurst.PullRequestScanner.AzureDevOps.Extensions;
+
+public static class AsyncEnumerableExtensions
+{
+    public static async Task<ImmutableList<T>> ToImmutableList<T>(this IAsyncEnumerable<T> items,
+        CancellationToken cancellationToken = default)
+    {
+        var results = new List<T>();
+
+        await foreach (var item in items.WithCancellation(cancellationToken)
+                           .ConfigureAwait(false))
+        {
+            results.Add(item);
+        }
+
+        return results.ToImmutableList();
+    }
+}

--- a/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/AzureDevOpsHttpClientExtensions.cs
+++ b/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/AzureDevOpsHttpClientExtensions.cs
@@ -1,0 +1,137 @@
+﻿using System.Runtime.CompilerServices;
+using TomLonghurst.PullRequestScanner.AzureDevOps.Http;
+using TomLonghurst.PullRequestScanner.AzureDevOps.Models;
+
+namespace TomLonghurst.PullRequestScanner.AzureDevOps.Extensions;
+
+internal static class AzureDevOpsHttpClientExtensions
+{
+    public static async IAsyncEnumerable<AzureDevOpsPullRequest> GetPullRequests(this AzureDevOpsHttpClient azureDevOpsHttpClient, string repositoryId, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = await azureDevOpsHttpClient.GetAll<AzureDevOpsPullRequestsResponse>(
+            $"_apis/git/pullrequests?searchCriteria.status=all&searchCriteria.includeLinks=false&searchCriteria.repositoryId={repositoryId}&includeCommits=true&api-version=7.1-preview.1", cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var azureDevOpsPullRequestsResponse in response)
+        {
+            foreach (AzureDevOpsPullRequest azureDevOpsPullRequest in azureDevOpsPullRequestsResponse.PullRequests)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    yield break;
+                }
+
+                yield return azureDevOpsPullRequest;
+            }
+        }
+    }
+
+    public static async IAsyncEnumerable<AzureDevOpsPullRequestIteration> ListPullRequestIterations(this AzureDevOpsHttpClient azureDevOpsHttpClient, string repositoryId, int pullRequestId, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = await azureDevOpsHttpClient.Get<AzureDevOpsPullRequestIterationResponse>(
+            $"_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}/statuses?api-version=7.1-preview.1", cancellationToken).ConfigureAwait(false);
+
+        if (response is null)
+        {
+            yield break;
+        }
+
+        foreach (var azureDevOpsPullRequestIteration in response.Value)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                yield break;
+            }
+
+            yield return azureDevOpsPullRequestIteration;
+        }
+    }
+
+    public static async IAsyncEnumerable<AzureDevOpsPullRequestThread> ListPullRequestThreads(this AzureDevOpsHttpClient azureDevOpsHttpClient, string repositoryId, int pullRequestId, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = await azureDevOpsHttpClient.Get<AzureDevOpsPullRequestThreadResponse>(
+            $"_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}/threads?api-version=7.1-preview.1", cancellationToken).ConfigureAwait(false);
+
+        if (response is null)
+        {
+            yield break;
+        }
+
+        foreach (AzureDevOpsPullRequestThread azureDevOpsPullRequestThread in response.Threads)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                yield break;
+            }
+
+            yield return azureDevOpsPullRequestThread;
+        }
+    }
+    
+    public static async IAsyncEnumerable<AzureDevOpsTeamMember> ListTeamMembers(
+        this AzureDevOpsHttpClient azureDevOpsHttpClient, string project, string teamId, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = await azureDevOpsHttpClient.GetAll<AzureDevOpsTeamMembersResponseWrapper>(
+            $"_apis/projects/{project}/teams/{teamId}/members?api-version=7.1-preview.2", cancellationToken)
+            .ConfigureAwait(false);
+
+
+        foreach (var azureDevOpsTeamMembersResponseWrapper in response)
+        {
+            foreach (AzureDevOpsTeamMember azureDevOpsTeamMember in azureDevOpsTeamMembersResponseWrapper.Value)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    yield break;
+                }
+
+
+                yield return azureDevOpsTeamMember;
+            }
+
+            
+        }
+    }
+
+    public static async IAsyncEnumerable<AzureDevOpsTeam> ListTeams(
+        this AzureDevOpsHttpClient azureDevOpsHttpClient, string project, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = await azureDevOpsHttpClient
+            .GetAll<AzureDevOpsTeamWrapper>($"_apis/projects/{project}/teams?api-version=7.1-preview.2", cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (AzureDevOpsTeamWrapper azureDevOpsTeamWrapper in response)
+        {
+            foreach (AzureDevOpsTeam azureDevOpsTeam in azureDevOpsTeamWrapper.Value)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    yield break;
+                }
+
+                yield return azureDevOpsTeam;
+            }
+        }
+    }
+
+    public static async IAsyncEnumerable<AzureDevOpsGitRepository> ListGitRepositories(
+        this AzureDevOpsHttpClient azureDevOpsHttpClient, string project, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = await azureDevOpsHttpClient
+            .GetAll<AzureDevOpsGitRepositoryResponse>($"{project}/_apis/git/repositories?api-version=7.1-preview.1", cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (AzureDevOpsGitRepositoryResponse azureDevOpsGitRepositoryResponse in response)
+        {
+            foreach (AzureDevOpsGitRepository azureDevOpsGitRepository in azureDevOpsGitRepositoryResponse.Repositories)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    yield break;
+                }
+
+                yield return azureDevOpsGitRepository;
+            }
+        }
+    }
+}

--- a/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/PullRequestScannerBuilderExtensions.cs
+++ b/TomLonghurst.PullRequestScanner.AzureDevOps/Extensions/PullRequestScannerBuilderExtensions.cs
@@ -35,12 +35,14 @@ public static class PullRequestScannerBuilderExtensions
                     new MediaTypeWithQualityHeaderValue("application/json"));
 
                 var azureDevOpsOptions = provider.GetRequiredService<AzureDevOpsOptions>();
+
+
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic",
-                    Convert.ToBase64String(Encoding.ASCII.GetBytes(FormatAccessToken(azureDevOpsOptions?.PersonalAccessToken))));
+                    Convert.ToBase64String(Encoding.ASCII.GetBytes(FormatAccessToken(azureDevOpsOptions.PersonalAccessToken))));
 
                 client.BaseAddress =
                     new Uri(
-                        $"https://dev.azure.com/{azureDevOpsOptions.OrganizationSlug}/{azureDevOpsOptions.ProjectSlug}/_apis/git/");
+                        $"https://dev.azure.com/{azureDevOpsOptions.OrganizationSlug}/");
             });
 
         pullRequestScannerBuilder.Services.AddTransient<IAzureDevOpsGitRepositoryService, AzureDevOpsGitRepositoryService>()

--- a/TomLonghurst.PullRequestScanner.AzureDevOps/Options/AzureDevOpsOptions.cs
+++ b/TomLonghurst.PullRequestScanner.AzureDevOps/Options/AzureDevOpsOptions.cs
@@ -13,10 +13,33 @@ public class AzureDevOpsOptions
      * <summary>The URL slug for the team</summary>
      */
     public string ProjectSlug { get; set; }
+
+    public IReadOnlyCollection<string>? Projects { get; set; }
+
     /**
      * <summary>Personal Access Token, usually in the format of "{username}:{PAT}"</summary>
      */
     public string PersonalAccessToken { get; set; }
 
     public Func<AzureDevOpsGitRepository, bool> RepositoriesToScan { get; set; } = _ => true;
+
+    public IEnumerable<string> GetProjects()
+    {
+        HashSet<string> distinctProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(ProjectSlug))
+        {
+            distinctProjects.Add(ProjectSlug);
+        }
+
+        if (Projects is not null)
+        {
+            foreach (string project in Projects)
+            {
+                distinctProjects.Add(project);
+            }
+        }
+
+        return distinctProjects;
+    }
 }

--- a/TomLonghurst.PullRequestScanner.AzureDevOps/Services/AzureDevOpsPullRequestProvider.cs
+++ b/TomLonghurst.PullRequestScanner.AzureDevOps/Services/AzureDevOpsPullRequestProvider.cs
@@ -56,9 +56,17 @@ internal class AzureDevOpsPullRequestProvider : IPullRequestProvider
         }
         
         ValidatePopulated(_azureDevOpsOptions.OrganizationSlug, nameof(_azureDevOpsOptions.OrganizationSlug));
-        ValidatePopulated(_azureDevOpsOptions.ProjectSlug, nameof(_azureDevOpsOptions.ProjectSlug));
+        ValidateCollectionPopulated(_azureDevOpsOptions.GetProjects(), nameof(_azureDevOpsOptions.ProjectSlug));
         ValidatePopulated(_azureDevOpsOptions.PersonalAccessToken, nameof(_azureDevOpsOptions.PersonalAccessToken));
-        
+
+        void ValidateCollectionPopulated(IEnumerable<string> value, string propertyName)
+        {
+            if (!value.Any())
+            {
+                throw new ArgumentNullException(propertyName);
+            }
+        }
+
         void ValidatePopulated(string value, string propertyName)
         {
             if (string.IsNullOrEmpty(value))

--- a/TomLonghurst.PullRequestScanner.AzureDevOps/Services/DevOpsPullRequestService.cs
+++ b/TomLonghurst.PullRequestScanner.AzureDevOps/Services/DevOpsPullRequestService.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Immutable;
+using TomLonghurst.PullRequestScanner.AzureDevOps.Extensions;
 using TomLonghurst.PullRequestScanner.AzureDevOps.Http;
 using TomLonghurst.PullRequestScanner.AzureDevOps.Models;
+using TomLonghurst.PullRequestScanner.AzureDevOps.Options;
+using TomLonghurst.PullRequestScanner.Extensions;
 
 namespace TomLonghurst.PullRequestScanner.AzureDevOps.Services;
 
@@ -8,25 +11,33 @@ internal class AzureDevOpsPullRequestService : IAzureDevOpsPullRequestService
 {
     private readonly AzureDevOpsHttpClient _devOpsHttpClient;
 
-    public AzureDevOpsPullRequestService(AzureDevOpsHttpClient azureDevOpsHttpClient)
+    public AzureDevOpsPullRequestService(AzureDevOpsHttpClient azureDevOpsHttpClient, AzureDevOpsOptions azureDevOpsOptions)
     {
         _devOpsHttpClient = azureDevOpsHttpClient;
     }
     
     public async Task<IReadOnlyList<AzureDevOpsPullRequestContext>> GetPullRequestsForRepository(AzureDevOpsGitRepository githubGitRepository)
     {
-        var response = await _devOpsHttpClient.GetAll<AzureDevOpsPullRequestsResponse>($"pullrequests?searchCriteria.status=all&searchCriteria.includeLinks=false&searchCriteria.repositoryId={githubGitRepository.Id}&includeCommits=true&api-version=7.1-preview.1");
-        var nonDraftedPullRequests = response.SelectMany(x => x.PullRequests)
+        var pullRequests = await _devOpsHttpClient
+            .GetPullRequests(githubGitRepository.Id)
+            .ToImmutableList();
+        
+        var nonDraftedPullRequests = pullRequests
             .Where(IsActiveOrRecentlyClosed);
 
         var pullRequestsWithThreads = new List<AzureDevOpsPullRequestContext>();
 
         foreach (var pullRequest in nonDraftedPullRequests)
         {
-            var threads = await GetThreads(pullRequest);
-            
-            var iterations = await GetIterations(pullRequest);
-            
+            var threads =
+                await _devOpsHttpClient
+                    .ListPullRequestThreads(pullRequest.Repository.Id, pullRequest.PullRequestId)
+                    .ToImmutableList();
+
+            var iterations = await _devOpsHttpClient
+                .ListPullRequestIterations(pullRequest.Repository.Id, pullRequest.PullRequestId)
+                .ToImmutableList();
+
             pullRequestsWithThreads.Add(new AzureDevOpsPullRequestContext
             {
                 AzureDevOpsPullRequest = pullRequest,
@@ -51,21 +62,5 @@ internal class AzureDevOpsPullRequestService : IAzureDevOpsPullRequestService
         }
 
         return false;
-    }
-
-    private async Task<IReadOnlyList<AzureDevOpsPullRequestThread>> GetThreads(AzureDevOpsPullRequest githubPullRequest)
-    {
-        var response = await _devOpsHttpClient.Get<AzureDevOpsPullRequestThreadResponse>(
-            $"repositories/{githubPullRequest.Repository.Id}/pullRequests/{githubPullRequest.PullRequestId}/threads?api-version=7.1-preview.1");
-
-        return response.Threads.ToImmutableList();
-    }
-
-    private async Task<IReadOnlyList<AzureDevOpsPullRequestIteration>> GetIterations(AzureDevOpsPullRequest githubPullRequest)
-    {
-        var response = await _devOpsHttpClient.Get<AzureDevOpsPullRequestIterationResponse>(
-            $"repositories/{githubPullRequest.Repository.Id}/pullRequests/{githubPullRequest.PullRequestId}/statuses?api-version=7.1-preview.1");
-
-        return response.Value.ToImmutableList();
     }
 }

--- a/TomLonghurst.PullRequestScanner/Extensions/EnumerableExtenions.cs
+++ b/TomLonghurst.PullRequestScanner/Extensions/EnumerableExtenions.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using TomLonghurst.PullRequestScanner.Models;
+﻿using TomLonghurst.PullRequestScanner.Models;
 
 namespace TomLonghurst.PullRequestScanner.Extensions;
 

--- a/TomLonghurst.PullRequestScanner/Extensions/EnumerableExtenions.cs
+++ b/TomLonghurst.PullRequestScanner/Extensions/EnumerableExtenions.cs
@@ -1,4 +1,5 @@
-﻿using TomLonghurst.PullRequestScanner.Models;
+﻿using System.Runtime.CompilerServices;
+using TomLonghurst.PullRequestScanner.Models;
 
 namespace TomLonghurst.PullRequestScanner.Extensions;
 


### PR DESCRIPTION
In my organisation I have a need to be able to scan more than one Azure DevOps project. We have multiple teams working across multiple projects with multiple repos. To keep on top of all the pull requests we are using the pull request scanner in conjunction with a PR dashboard.

After a short trial, the team have been happy with the PR scanner, they really like the reviewer leader board. With the current setup I have multiple function apps setup all posting to the same channel in Teams but it means we have separate leader boards for each project.

What I have done is changed the Azure DevOps plugin to allow you to specify one or more project(s) and scan them all together so that we end up with a single set of results for our entire Azure DevOps organisation.

I was 50/50 about either creating an new plug or editing the existing project. I went with editing the existing project (in a backwards compatible way) but I am happy if you prefer I create a separate plugin.